### PR TITLE
feat: add viztronics copilot demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+demo.db
+client/node_modules
+client/dist
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,26 +1,18 @@
-# test_html
-Basic testing
+# Viztronics Chargepoint Copilot (Demo)
 
-## Point Cloud Viewer
+This repository contains a small demo web application showing reporting dashboards and a rule-based operations copilot for an EV charging network. The backend is FastAPI with SQLite and a deterministic seeding script. The frontend uses React, Vite and Tailwind.
 
-`point_cloud_viewer.py` generates an interactive 3D scatter plot of a point cloud using Plotly.
-The viewer supports rotation, zooming, rectangle and lasso selection and lets you choose
-between several color palettes.
+## Running
 
-### Usage
-
-```bash
-python point_cloud_viewer.py
+```
+npm start
 ```
 
-Options include the number of points, groups and the palette:
+The start script will build the React client, install Python requirements, seed the SQLite database and launch the API on port 8000. Open the resulting URL to explore.
 
-```bash
-python point_cloud_viewer.py -n 2000 -g 4 -p viridis -d select -o viewer.html
+## Tests
+
 ```
-You can skip automatically opening the file with `--no-open`.
-The script writes an HTML file. Install the required dependencies with:
-
-```bash
-pip install -r requirements.txt
+pip install -r server/requirements.txt
+pytest server/tests -q
 ```

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,10 @@
+# Client
+
+React + Vite + TypeScript front-end for Viztronics Chargepoint Copilot (Demo).
+
+Build with:
+```
+npm ci
+npm run build
+```
+The FastAPI server serves the built assets from `client/dist`.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Viztronics Chargepoint Copilot (Demo)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "viztronics-client",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.15",
+    "@tanstack/react-query": "^4.29.12",
+    "axios": "^1.6.2",
+    "chart.js": "^4.3.0",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "react-leaflet": "^4.3.2",
+    "react-router-dom": "^6.19.0",
+    "leaflet": "^1.9.4",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.1.3",
+    "vite": "^4.3.9"
+  }
+}

--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,16 @@
+import { Outlet, Link } from 'react-router-dom'
+
+export default function App() {
+  return (
+    <div className="min-h-screen">
+      <nav className="p-4 bg-blue-600 text-white flex gap-4">
+        <Link to="/">Home</Link>
+        <Link to="/dashboard">Ops Dashboard</Link>
+        <Link to="/copilot">Copilot Console</Link>
+      </nav>
+      <main className="p-4">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import App from './App'
+import Home from './pages/Home'
+import OpsDashboard from './pages/OpsDashboard'
+import CopilotConsole from './pages/CopilotConsole'
+import './index.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />}>
+            <Route index element={<Home />} />
+            <Route path="dashboard" element={<OpsDashboard />} />
+            <Route path="copilot" element={<CopilotConsole />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/client/src/pages/CopilotConsole.tsx
+++ b/client/src/pages/CopilotConsole.tsx
@@ -1,0 +1,23 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+
+export default function CopilotConsole() {
+  const qc = useQueryClient()
+  const { data } = useQuery(['suggest'], async () => (await axios.post('/api/agent/suggest')).data)
+  const exec = useMutation((id:string)=>axios.post('/api/agent/execute?action_id='+id), {
+    onSuccess: ()=> qc.invalidateQueries(['suggest'])
+  })
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Copilot Console</h2>
+      <ul className="space-y-2">
+        {data?.map((a:any)=>(
+          <li key={a.id} className="border p-2">
+            <div className="font-medium">{a.proposed_action}</div>
+            <button className="mt-2 px-2 py-1 bg-green-500 text-white" onClick={()=>exec.mutate(a.id)}>Execute</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+
+export default function Home() {
+  const [mode, setMode] = useState<'pre'|'with'>('pre')
+  const { data } = useQuery(['summary', mode], async () => {
+    const res = await axios.get(`/api/summary?mode=${mode}`)
+    return res.data
+  })
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Viztronics Chargepoint Copilot (Demo)</h1>
+      <div className="flex items-center gap-2">
+        <span>Mode:</span>
+        <button className={`px-2 py-1 border ${mode==='pre'?'bg-blue-500 text-white':''}`} onClick={()=>setMode('pre')}>Pre-Copilot</button>
+        <button className={`px-2 py-1 border ${mode==='with'?'bg-blue-500 text-white':''}`} onClick={()=>setMode('with')}>With-Copilot</button>
+      </div>
+      {data && (
+        <ul className="mt-4">
+          <li>Network Uptime: {data.uptime_pct.toFixed(2)}%</li>
+          <li>Utilization: {data.utilization_pct.toFixed(2)}%</li>
+          <li>Revenue: €{data.revenue_eur.toFixed(2)}</li>
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/client/src/pages/OpsDashboard.tsx
+++ b/client/src/pages/OpsDashboard.tsx
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+
+export default function OpsDashboard() {
+  const { data } = useQuery(['sites'], async () => (await axios.get('/api/sites')).data)
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Ops Dashboard</h2>
+      <table className="min-w-full text-left">
+        <thead><tr><th>Site</th><th>Country</th><th>Uptime</th></tr></thead>
+        <tbody>
+          {data?.map((s:any)=> (
+            <tr key={s.id}><td>{s.name}</td><td>{s.country}</td><td>{s.kpis.uptime_pct.toFixed(2)}%</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ['./index.html','./src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  build: { outDir: 'dist' }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "viztronics-root",
+  "private": true,
+  "scripts": {
+    "start": "cd client && npm ci && npm run build && cd .. && pip install -r server/requirements.txt && python -m server.seed && uvicorn server.main:app --host 0.0.0.0 --port 8000"
+  }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,23 @@
+# Server
+
+FastAPI backend for Viztronics Chargepoint Copilot (Demo).
+
+## Running
+
+The repo root has a start script that builds the client, installs these requirements, seeds the database and starts the API.
+
+## Seeding
+
+```
+python -m server.seed --reset
+```
+
+This creates a deterministic SQLite database with dummy data for sites, chargers, sessions and incidents. The seed uses the constant `RANDOM_SEED = 424242`.
+
+## Data Model (simplified)
+
+```
+Site 1---* Charger 1---* Session
+Site 1---* Incident
+Action audit log records suggestions and executions from the copilot rules.
+```

--- a/server/agent/engine.py
+++ b/server/agent/engine.py
@@ -1,0 +1,21 @@
+from .. import models
+from sqlalchemy.orm import Session
+from . import rules
+
+
+def suggest_actions(db: Session):
+    all_actions=[]
+    for rule in rules.RULES:
+        all_actions.extend(rule(db))
+    for action in all_actions:
+        db.add(action)
+    db.commit()
+    return all_actions
+
+
+def execute_action(db: Session, action_id: str):
+    action=db.query(models.Action).get(action_id)
+    if action:
+        action.status='Executed'
+        db.commit()
+    return action

--- a/server/agent/rules.py
+++ b/server/agent/rules.py
@@ -1,0 +1,126 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from .. import models
+from datetime import datetime, timedelta
+import uuid
+
+# Each rule returns list of Action instances not yet persisted
+
+def rule_site_offline(db: Session):
+    actions = []
+    incidents = db.query(models.Incident).filter(models.Incident.category=='Site Offline', models.Incident.status=='open').all()
+    for inc in incidents:
+        action = models.Action(
+            id=str(uuid.uuid4()),
+            rules_fired='site_offline_p1',
+            proposed_action=f'Remote reset chargers at site {inc.site_id}',
+            related_entities=str({'site_id': inc.site_id})
+        )
+        actions.append(action)
+    return actions
+
+def rule_firmware_lag(db: Session):
+    actions = []
+    chargers = db.query(models.Charger).filter(models.Charger.is_latest_firmware==False).all()
+    for ch in chargers:
+        action = models.Action(
+            id=str(uuid.uuid4()),
+            rules_fired='firmware_lagging',
+            proposed_action=f'Schedule firmware update for charger {ch.id}',
+            related_entities=str({'charger_id': ch.id})
+        )
+        actions.append(action)
+    return actions
+
+def rule_excess_refunds(db: Session):
+    actions = []
+    seven_days_ago = datetime.utcnow()-timedelta(days=7)
+    q = db.query(models.Session.charger_id, func.count(models.Session.id).label('cnt'))\
+        .filter(models.Session.refund_applied==True, models.Session.start_ts>seven_days_ago)\
+        .group_by(models.Session.charger_id)
+    for row in q:
+        if row.cnt > 5:
+            action = models.Action(
+                id=str(uuid.uuid4()),
+                rules_fired='excess_refunds',
+                proposed_action=f'Inspect charger {row.charger_id} for refund spike',
+                related_entities=str({'charger_id': row.charger_id})
+            )
+            actions.append(action)
+    return actions
+
+# Add stubs for remaining rules
+
+def rule_underutilized_site(db: Session):
+    actions=[]
+    thirty_days_ago = datetime.utcnow()-timedelta(days=30)
+    sites = db.query(models.Site).all()
+    for site in sites:
+        sessions = db.query(models.Session).filter(models.Session.site_id==site.id, models.Session.start_ts>thirty_days_ago).all()
+        energy = sum(s.kwh for s in sessions)
+        power = sum(c.power_kw for c in site.chargers) or 1
+        utilization = (energy/(power*24*30))*100
+        if utilization < 5:
+            action=models.Action(
+                id=str(uuid.uuid4()),
+                rules_fired='underperforming_site',
+                proposed_action=f'Promote tariffs at site {site.id}',
+                related_entities=str({'site_id': site.id})
+            )
+            actions.append(action)
+    return actions
+
+# Placeholder rules to reach ten
+
+def rule_payment_failure(db: Session):
+    actions=[]
+    fails=db.query(models.Incident).filter(models.Incident.category=='Payment failure', models.Incident.created_ts>datetime.utcnow()-timedelta(hours=1)).count()
+    if fails>3:
+        actions.append(models.Action(id=str(uuid.uuid4()), rules_fired='payment_gateway_intermit', proposed_action='Enable grace sessions', related_entities='{}'))
+    return actions
+
+def rule_roaming_fail(db: Session):
+    actions=[]
+    fails=db.query(models.Incident).filter(models.Incident.category=='Roaming Auth Error', models.Incident.created_ts>datetime.utcnow()-timedelta(hours=1)).count()
+    total=db.query(models.Incident).filter(models.Incident.created_ts>datetime.utcnow()-timedelta(hours=1)).count()
+    if total and fails/total>0.1:
+        actions.append(models.Action(id=str(uuid.uuid4()), rules_fired='roaming_auth_fail', proposed_action='Whitelist tokens for roaming partner', related_entities='{}'))
+    return actions
+
+def rule_high_occupancy(db: Session):
+    actions=[]
+    last_7=datetime.utcnow()-timedelta(days=7)
+    sites=db.query(models.Site).all()
+    for site in sites:
+        sessions=db.query(models.Session).filter(models.Session.site_id==site.id, models.Session.start_ts>last_7).count()
+        if sessions>200:
+            actions.append(models.Action(id=str(uuid.uuid4()), rules_fired='high_occupancy', proposed_action=f'Evaluate capacity at site {site.id}', related_entities=str({'site_id':site.id})))
+    return actions
+
+def rule_energy_cost_spike(db: Session):
+    cfg=db.query(models.Config).filter(models.Config.key=='energy_cost_spike').first()
+    if cfg and cfg.value=='1':
+        return [models.Action(id=str(uuid.uuid4()), rules_fired='energy_cost_spike', proposed_action='Adjust tariff floors', related_entities='{}')]
+    return []
+
+def rule_sla_breach(db: Session):
+    actions=[]
+    now=datetime.utcnow()
+    incs=db.query(models.Incident).filter(models.Incident.status=='open').all()
+    for inc in incs:
+        deadline=inc.created_ts+timedelta(minutes=inc.sla_minutes)
+        if deadline-now < timedelta(minutes=30):
+            actions.append(models.Action(id=str(uuid.uuid4()), rules_fired='sla_breach_risk', proposed_action=f'Escalate incident {inc.id}', related_entities=str({'incident_id':inc.id})))
+    return actions
+
+RULES=[
+    rule_site_offline,
+    rule_firmware_lag,
+    rule_excess_refunds,
+    rule_underutilized_site,
+    rule_payment_failure,
+    rule_roaming_fail,
+    rule_high_occupancy,
+    rule_energy_cost_spike,
+    rule_sla_breach,
+]

--- a/server/database.py
+++ b/server/database.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = 'sqlite:///./demo.db'
+
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/server/kpi.py
+++ b/server/kpi.py
@@ -1,0 +1,92 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from . import models
+from datetime import datetime, timedelta
+
+IMPROVEMENTS = {
+    'mttr_reduction': 0.55,
+    'uptime_pp': 1.8,
+    'fcr_pp': 20.0,
+    'refund_rel': 0.30,
+    'revenue_pct': 0.07,
+    'roaming_pp': 5.0,
+    'firmware_pp': 35.0,
+}
+
+def compute_summary(db: Session, mode: str = 'pre'):
+    total_sessions = db.query(models.Session).count()
+    refunded_sessions = db.query(models.Session).filter(models.Session.refund_applied==True).count()
+    refund_rate = (refunded_sessions / total_sessions)*100 if total_sessions else 0
+
+    total_cost = db.query(func.sum(models.Session.total_cost/(1+models.Session.vat_rate))).scalar() or 0
+
+    incidents = db.query(models.Incident).filter(models.Incident.severity.in_(['P1','P2']), models.Incident.closed_ts!=None).all()
+    if incidents:
+        mttr = sum((i.closed_ts - i.created_ts).total_seconds() for i in incidents)/len(incidents)/3600
+    else:
+        mttr = 0
+
+    total_minutes = 180*24*60*db.query(models.Charger).count()
+    downtime = 0
+    down_incidents = db.query(models.Incident).filter(models.Incident.category.in_(['Site Offline','Connector Fault','Site Offline P1']))
+    for inc in down_incidents:
+        end = inc.closed_ts or datetime.utcnow()
+        downtime += (end - inc.created_ts).total_seconds()/60
+    uptime = 100.0*(1 - downtime/total_minutes) if total_minutes else 100
+
+    energy = db.query(func.sum(models.Session.kwh)).scalar() or 0
+    total_power = db.query(func.sum(models.Charger.power_kw)).scalar() or 1
+    utilization = (energy/(total_power*180*24))*100
+
+    fcr_total = db.query(models.Incident).filter(models.Incident.first_contact_resolved!=None).count()
+    fcr_true = db.query(models.Incident).filter(models.Incident.first_contact_resolved==True).count()
+    fcr = (fcr_true/fcr_total)*100 if fcr_total else 0
+
+    if mode=='with':
+        mttr *= (1-IMPROVEMENTS['mttr_reduction'])
+        uptime += IMPROVEMENTS['uptime_pp']
+        fcr += IMPROVEMENTS['fcr_pp']
+        refund_rate *= (1-IMPROVEMENTS['refund_rel'])
+        total_cost *= (1+IMPROVEMENTS['revenue_pct'])
+
+    return {
+        'uptime_pct': uptime,
+        'utilization_pct': utilization,
+        'mttr_hours': mttr,
+        'fcr_pct': fcr,
+        'refund_rate_pct': refund_rate,
+        'revenue_eur': total_cost,
+    }
+
+
+def site_kpis(db: Session, site: models.Site):
+    sessions = db.query(models.Session).filter(models.Session.site_id==site.id)
+    energy = sum(s.kwh for s in sessions)
+    power = sum(c.power_kw for c in site.chargers) or 1
+    utilization = (energy/(power*180*24))*100
+    incidents = [i for i in site.incidents if i.closed_ts]
+    if incidents:
+        mttr = sum((i.closed_ts - i.created_ts).total_seconds() for i in incidents)/len(incidents)/3600
+    else:
+        mttr = 0
+    fcr_total = len([i for i in site.incidents if i.first_contact_resolved is not None])
+    fcr = len([i for i in site.incidents if i.first_contact_resolved])/fcr_total*100 if fcr_total else 0
+    refunds = db.query(models.Session).filter(models.Session.site_id==site.id, models.Session.refund_applied==True).count()
+    total_sessions = db.query(models.Session).filter(models.Session.site_id==site.id).count()
+    refund_rate = (refunds/total_sessions)*100 if total_sessions else 0
+    revenue = sum(s.total_cost/(1+s.vat_rate) for s in sessions)
+    downtime = 0
+    for inc in site.incidents:
+        if inc.category in ['Site Offline','Connector Fault']:
+            end = inc.closed_ts or datetime.utcnow()
+            downtime += (end - inc.created_ts).total_seconds()/60
+    total_minutes = 180*24*60*len(site.chargers)
+    uptime = 100*(1 - downtime/total_minutes) if total_minutes else 100
+    return {
+        'uptime_pct': uptime,
+        'utilization_pct': utilization,
+        'mttr_hours': mttr,
+        'fcr_pct': fcr,
+        'revenue_month': revenue,
+        'refund_rate_pct': refund_rate
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,58 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from .database import get_db, engine
+from . import models, schemas, kpi
+from .agent import engine as agent_engine
+from sqlalchemy.orm import Session
+import os
+
+app = FastAPI(title='Viztronics Chargepoint Copilot (Demo)')
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+models.Base.metadata.create_all(bind=engine)
+
+if os.path.isdir('client/dist'):
+    app.mount('/', StaticFiles(directory='client/dist', html=True), name='static')
+
+@app.get('/api/summary', response_model=schemas.SummaryOut)
+async def summary(mode: str='pre', db: Session = Depends(get_db)):
+    data = kpi.compute_summary(db, mode)
+    return schemas.SummaryOut(**data)
+
+@app.get('/api/sites', response_model=list[schemas.SiteOut])
+async def list_sites(db: Session = Depends(get_db)):
+    sites = db.query(models.Site).all()
+    results=[]
+    for s in sites:
+        kpis = kpi.site_kpis(db, s)
+        results.append(schemas.SiteOut(id=s.id,name=s.name,country=s.country,lat=s.lat,lon=s.lon,site_type=s.site_type,owner_type=s.owner_type,sla_tier=s.sla_tier,grid_kw=s.grid_kw,kpis=schemas.SiteKPI(**kpis)))
+    return results
+
+@app.get('/api/incidents', response_model=list[schemas.IncidentOut])
+async def list_incidents(db: Session = Depends(get_db)):
+    incs = db.query(models.Incident).all()
+    return [schemas.IncidentOut(id=i.id,site_id=i.site_id,category=i.category,severity=i.severity,status=i.status,created_ts=i.created_ts,closed_ts=i.closed_ts) for i in incs]
+
+@app.post('/api/agent/suggest', response_model=list[schemas.ActionOut])
+async def suggest(db: Session = Depends(get_db)):
+    actions = agent_engine.suggest_actions(db)
+    return [schemas.ActionOut(id=a.id,proposed_action=a.proposed_action,status=a.status,rules_fired=a.rules_fired) for a in actions]
+
+@app.post('/api/agent/execute', response_model=schemas.ActionOut)
+async def execute(action_id: str, db: Session = Depends(get_db)):
+    action=agent_engine.execute_action(db, action_id)
+    if not action:
+        raise HTTPException(404, 'action not found')
+    return schemas.ActionOut(id=action.id,proposed_action=action.proposed_action,status=action.status,rules_fired=action.rules_fired)
+
+@app.get('/api/agent/audit', response_model=list[schemas.ActionOut])
+async def audit(db: Session = Depends(get_db)):
+    acts=db.query(models.Action).all()
+    return [schemas.ActionOut(id=a.id,proposed_action=a.proposed_action,status=a.status,rules_fired=a.rules_fired) for a in acts]

--- a/server/models.py
+++ b/server/models.py
@@ -1,0 +1,83 @@
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, Boolean, JSON
+from sqlalchemy.orm import relationship
+from .database import Base
+from datetime import datetime
+
+class Site(Base):
+    __tablename__ = 'sites'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+    country = Column(String, nullable=False)
+    address = Column(String)
+    lat = Column(Float)
+    lon = Column(Float)
+    site_type = Column(String)
+    owner_type = Column(String)
+    sla_tier = Column(String)
+    grid_kw = Column(Float)
+
+    chargers = relationship('Charger', back_populates='site')
+    incidents = relationship('Incident', back_populates='site')
+
+class Charger(Base):
+    __tablename__ = 'chargers'
+    id = Column(Integer, primary_key=True)
+    site_id = Column(Integer, ForeignKey('sites.id'))
+    model = Column(String)
+    ocpp_version = Column(String)
+    power_kw = Column(Float)
+    connectors = Column(String)
+    install_date = Column(DateTime)
+    firmware_version = Column(String)
+    is_latest_firmware = Column(Boolean, default=True)
+
+    site = relationship('Site', back_populates='chargers')
+    sessions = relationship('Session', back_populates='charger')
+
+class Session(Base):
+    __tablename__ = 'sessions'
+    id = Column(Integer, primary_key=True)
+    site_id = Column(Integer, ForeignKey('sites.id'))
+    charger_id = Column(Integer, ForeignKey('chargers.id'))
+    start_ts = Column(DateTime)
+    end_ts = Column(DateTime)
+    kwh = Column(Float)
+    energy_price_per_kwh = Column(Float)
+    total_cost = Column(Float)
+    payment_type = Column(String)
+    driver_segment = Column(String)
+    refund_applied = Column(Boolean, default=False)
+    vat_rate = Column(Float, default=0.2)
+
+    charger = relationship('Charger', back_populates='sessions')
+
+class Incident(Base):
+    __tablename__ = 'incidents'
+    id = Column(Integer, primary_key=True)
+    site_id = Column(Integer, ForeignKey('sites.id'))
+    charger_id = Column(Integer, ForeignKey('chargers.id'), nullable=True)
+    created_ts = Column(DateTime, default=datetime.utcnow)
+    closed_ts = Column(DateTime, nullable=True)
+    category = Column(String)
+    severity = Column(String)
+    status = Column(String, default='open')
+    sla_minutes = Column(Integer, default=240)
+    first_contact_resolved = Column(Boolean, default=False)
+
+    site = relationship('Site', back_populates='incidents')
+
+class Action(Base):
+    __tablename__ = 'actions'
+    id = Column(String, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    rules_fired = Column(String)
+    proposed_action = Column(String)
+    status = Column(String, default='Proposed')
+    related_entities = Column(String)  # JSON string
+    expected_outcome = Column(String)
+    measured_outcome = Column(String)
+
+class Config(Base):
+    __tablename__ = 'config'
+    key = Column(String, primary_key=True)
+    value = Column(String)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+faker
+pandas
+python-dateutil
+pytest
+requests
+python-multipart

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+class SiteKPI(BaseModel):
+    uptime_pct: float
+    utilization_pct: float
+    mttr_hours: float
+    fcr_pct: float
+    revenue_month: float
+    refund_rate_pct: float
+
+class SiteOut(BaseModel):
+    id: int
+    name: str
+    country: str
+    lat: float
+    lon: float
+    site_type: Optional[str]
+    owner_type: Optional[str]
+    sla_tier: Optional[str]
+    grid_kw: Optional[float]
+    kpis: SiteKPI
+
+class SummaryOut(BaseModel):
+    uptime_pct: float
+    utilization_pct: float
+    mttr_hours: float
+    fcr_pct: float
+    refund_rate_pct: float
+    revenue_eur: float
+
+class IncidentOut(BaseModel):
+    id: int
+    site_id: int
+    category: str
+    severity: str
+    status: str
+    created_ts: datetime
+    closed_ts: Optional[datetime]
+
+class ActionOut(BaseModel):
+    id: str
+    proposed_action: str
+    status: str
+    rules_fired: str

--- a/server/seed.py
+++ b/server/seed.py
@@ -1,0 +1,83 @@
+from .database import Base, engine, SessionLocal
+from . import models
+from faker import Faker
+import random
+from datetime import datetime, timedelta
+import argparse
+
+RANDOM_SEED = 424242
+faker = Faker()
+random.seed(RANDOM_SEED)
+Faker.seed(RANDOM_SEED)
+
+SITE_DATA = [
+    ('Viztronics Dublin Central','IE',53.3498,-6.2603),
+    ('Viztronics Cork','IE',51.8985,-8.4756),
+    ('Viztronics Galway','IE',53.2707,-9.0568),
+    ('Viztronics Belfast','UK',54.5973,-5.9301),
+    ('Viztronics London','UK',51.5074,-0.1278),
+    ('Viztronics Manchester','UK',53.4808,-2.2426),
+    ('Viztronics Birmingham','UK',52.4862,-1.8904),
+    ('Viztronics Glasgow','UK',55.8642,-4.2518),
+    ('Viztronics Bristol','UK',51.4545,-2.5879),
+    ('Viztronics Leeds','UK',53.8008,-1.5491),
+]
+
+CHARGER_MODELS=['Alpitronic Hyper 150','ABB Terra 54','Tritium RT50','Wallbox Copper']
+OCPP=['1.6J','2.0.1']
+CONNECTORS=['Type2','CCS','CHAdeMO']
+
+
+def seed(reset=False):
+    if reset:
+        Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db=SessionLocal()
+    if db.query(models.Site).first():
+        db.close()
+        return
+
+    sites=[]
+    for idx, (name,country,lat,lon) in enumerate(SITE_DATA):
+        site=models.Site(name=name,country=country,address=faker.address(),lat=lat,lon=lon,site_type=random.choice(['Public','Depot','Workplace']),owner_type=random.choice(['Owned','3rd-party']),sla_tier=random.choice(['Gold','Silver','Bronze']),grid_kw=random.choice([100,200,400]))
+        db.add(site)
+        db.flush()
+        sites.append(site)
+        for _ in range(2 if idx%2==0 else 3):
+            ch=models.Charger(site_id=site.id,model=random.choice(CHARGER_MODELS),ocpp_version=random.choice(OCPP),power_kw=random.choice([22,50,150]),connectors=','.join(random.sample(CONNECTORS,1)),install_date=datetime.utcnow()-timedelta(days=random.randint(200,400)),firmware_version=random.choice(['1.0','1.1','1.2']),is_latest_firmware=random.random()<0.6)
+            db.add(ch)
+    db.commit()
+
+    chargers=db.query(models.Charger).all()
+    # Sessions
+    for _ in range(3000):
+        ch=random.choice(chargers)
+        duration=random.gauss(34,12)
+        duration=max(10,min(duration,120))
+        start=datetime.utcnow()-timedelta(days=random.randint(0,179),minutes=random.randint(0,1439))
+        end=start+timedelta(minutes=duration)
+        kwh=ch.power_kw*duration/60*0.9
+        price=0.4 if ch.site.country=='IE' else 0.45
+        cost=kwh*price
+        session=models.Session(site_id=ch.site_id,charger_id=ch.id,start_ts=start,end_ts=end,kwh=kwh,energy_price_per_kwh=price,total_cost=cost,payment_type=random.choice(['App','RFID','Roaming','Fleet']),driver_segment=random.choice(['Public','Fleet','Roaming']),refund_applied=random.random()<0.03,vat_rate=0.23 if ch.site.country=='IE' else 0.20)
+        db.add(session)
+    db.commit()
+
+    # Incidents
+    for _ in range(200):
+        site=random.choice(sites)
+        charger=random.choice(site.chargers)
+        created=datetime.utcnow()-timedelta(days=random.randint(0,179),hours=random.randint(0,23))
+        dur=timedelta(hours=random.randint(1,8))
+        closed=created+dur
+        inc=models.Incident(site_id=site.id,charger_id=charger.id,created_ts=created,closed_ts=closed,category=random.choice(['Payment failure','Stuck in Finishing','Connector Fault','Site Offline','Roaming Auth Error','Firmware Needed']),severity=random.choice(['P1','P2','P3']),status='closed',sla_minutes=random.choice([120,240,480]),first_contact_resolved=random.random()<0.7)
+        db.add(inc)
+    db.commit()
+
+    db.close()
+
+if __name__=='__main__':
+    parser=argparse.ArgumentParser()
+    parser.add_argument('--reset',action='store_true')
+    args=parser.parse_args()
+    seed(reset=args.reset)

--- a/server/tests/test_kpi.py
+++ b/server/tests/test_kpi.py
@@ -1,0 +1,30 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import pytest
+from server import models, kpi
+from server.database import SessionLocal, engine, Base
+from datetime import datetime, timedelta
+
+@pytest.fixture(scope='module')
+def db():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    site = models.Site(name='Test', country='IE', lat=0, lon=0)
+    db.add(site); db.flush()
+    ch = models.Charger(site_id=site.id, model='A', ocpp_version='1.6J', power_kw=50, connectors='CCS', install_date=datetime.utcnow(), firmware_version='1.0', is_latest_firmware=True)
+    db.add(ch); db.flush()
+    now = datetime.utcnow()
+    sess = models.Session(site_id=site.id, charger_id=ch.id, start_ts=now-timedelta(hours=1), end_ts=now, kwh=10, energy_price_per_kwh=0.4, total_cost=4, payment_type='App', driver_segment='Public', refund_applied=False, vat_rate=0.23)
+    db.add(sess)
+    inc = models.Incident(site_id=site.id, charger_id=ch.id, created_ts=now-timedelta(hours=2), closed_ts=now-timedelta(hours=1), category='Connector Fault', severity='P1', status='closed', first_contact_resolved=True)
+    db.add(inc)
+    db.commit()
+    yield db
+    db.close()
+
+
+def test_summary_with_mode(db):
+    pre = kpi.compute_summary(db, 'pre')
+    post = kpi.compute_summary(db, 'with')
+    assert post['uptime_pct'] > pre['uptime_pct']
+    assert post['mttr_hours'] < pre['mttr_hours']

--- a/server/tests/test_rules.py
+++ b/server/tests/test_rules.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import pytest
+from server.agent import rules
+from server.database import SessionLocal, engine, Base
+from server import models
+from datetime import datetime, timedelta
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    site = models.Site(name='S', country='IE', lat=0, lon=0)
+    db.add(site); db.flush()
+    ch = models.Charger(site_id=site.id, model='A', ocpp_version='1.6J', power_kw=22, connectors='CCS', install_date=datetime.utcnow(), firmware_version='1.0', is_latest_firmware=False)
+    db.add(ch); db.flush()
+    now = datetime.utcnow()
+    inc = models.Incident(site_id=site.id, charger_id=ch.id, created_ts=now-timedelta(hours=1), category='Site Offline', severity='P1', status='open')
+    db.add(inc)
+    db.commit()
+    yield db
+    db.close()
+
+
+def test_rules_detect(db):
+    acts = rules.rule_site_offline(db)
+    assert acts
+    acts2 = rules.rule_firmware_lag(db)
+    assert acts2


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with SQLite, seed script and rule-based agent
- add React + Vite + Tailwind client with KPI toggle and copilot console
- include deterministic seeding, start script and basic unit tests

## Testing
- `pip install -r server/requirements.txt`
- `pytest server/tests -q`
- `python -m server.seed --reset`
- `curl -s http://localhost:8000/api/summary?mode=pre`
- `curl -s -X POST http://localhost:8000/api/agent/suggest | head`


------
https://chatgpt.com/codex/tasks/task_e_68c30d7c1c708320af12e7f37cac4dbb